### PR TITLE
Remove continue buttons from neighborhood pages

### DIFF
--- a/PAGES/bloomfield.html
+++ b/PAGES/bloomfield.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Shadyside, where historic elegance meets modern luxury.</p>
-                <a href="shadyside.html" class="btn btn-primary mt-3">Continue to Shadyside</a>
             </div>
         </div>
     </section>

--- a/PAGES/bloomfield_fixed.html
+++ b/PAGES/bloomfield_fixed.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Shadyside, where historic elegance meets modern luxury.</p>
-                <a href="shadyside.html" class="btn btn-primary mt-3">Continue to Shadyside</a>
             </div>
         </div>
     </section>

--- a/PAGES/downtown.html
+++ b/PAGES/downtown.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Bloomfield, Pittsburgh's "Little Italy," where European heritage and culinary traditions await.</p>
-                <a href="bloomfield.html" class="btn btn-primary mt-3">Continue to Bloomfield</a>
             </div>
         </div>
     </section>

--- a/PAGES/lawrenceville.html
+++ b/PAGES/lawrenceville.html
@@ -98,7 +98,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to the Strip District, where the city's industrial past meets its culinary present.</p>
-                <a href="strip_district.html" class="btn btn-primary mt-3">Continue to Strip District</a>
                     <li><a href="downtown.html">Downtown</a></li>
             </div>
         </div>

--- a/PAGES/lawrenceville_fixed.html
+++ b/PAGES/lawrenceville_fixed.html
@@ -98,7 +98,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to the Strip District, where the city's industrial past meets its culinary present.</p>
-                <a href="strip_district.html" class="btn btn-primary mt-3">Continue to Strip District</a>
                     <li><a href="downtown.html">Downtown</a></li>
             </div>
         </div>

--- a/PAGES/regent_square.html
+++ b/PAGES/regent_square.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Congratulations!</h3>
                 <p>You've completed the BMW Charity Scavenger Hunt across Pittsburgh's vibrant neighborhoods. Return to any location to see your progress or start again from the beginning.</p>
-                <a href="lawrenceville.html" class="btn btn-primary mt-3">Return to Start</a>
             </div>
         </div>
     </section>

--- a/PAGES/regent_square_fixed.html
+++ b/PAGES/regent_square_fixed.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Congratulations!</h3>
                 <p>You've completed the BMW Charity Scavenger Hunt across Pittsburgh's vibrant neighborhoods. Return to any location to see your progress or start again from the beginning.</p>
-                <a href="lawrenceville.html" class="btn btn-primary mt-3">Return to Start</a>
             </div>
         </div>
     </section>

--- a/PAGES/shadyside.html
+++ b/PAGES/shadyside.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Complete your journey through Pittsburgh's vibrant neighborhoods by heading to Regent Square, where nature and community create a charming urban oasis.</p>
-                <a href="regent_square.html" class="btn btn-primary mt-3">Continue to Regent Square</a>
             </div>
         </div>
     </section>

--- a/PAGES/shadyside_fixed.html
+++ b/PAGES/shadyside_fixed.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Complete your journey through Pittsburgh's vibrant neighborhoods by heading to Regent Square, where nature and community create a charming urban oasis.</p>
-                <a href="regent_square.html" class="btn btn-primary mt-3">Continue to Regent Square</a>
             </div>
         </div>
     </section>

--- a/PAGES/strip_district.html
+++ b/PAGES/strip_district.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Downtown Pittsburgh, the city's central district brimming with cultural landmarks.</p>
-                <a href="downtown.html" class="btn btn-primary mt-3">Continue to Downtown</a>
             </div>
         </div>
     </section>

--- a/PAGES/strip_district_fixed.html
+++ b/PAGES/strip_district_fixed.html
@@ -93,7 +93,6 @@
             <div class="next-location-hint text-center mt-4 mb-5">
                 <h3>Your Next Destination</h3>
                 <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Downtown Pittsburgh, the city's central district brimming with cultural landmarks.</p>
-                <a href="downtown.html" class="btn btn-primary mt-3">Continue to Downtown</a>
             </div>
         </div>
     </section>

--- a/frontend/src/pages/NeighborhoodPage.jsx
+++ b/frontend/src/pages/NeighborhoodPage.jsx
@@ -322,7 +322,6 @@ const NeighborhoodPage = () => {
           <div style={{ textAlign: 'center', margin: '40px 0' }}>
             <h3 style={{ color: '#111' }}>Your Next Destination</h3>
             <p style={{ color: '#222' }}>{n.next.text}</p>
-            <Link to={`/location/${n.next.slug}`} style={{ display: 'inline-block', background: '#1c69d4', color: '#fff', padding: '12px 32px', borderRadius: 8, fontWeight: 'bold', fontSize: 18, textDecoration: 'none', marginTop: 16 }}>{n.next.label}</Link>
           </div>
         </section>
         {/* BMW Branding Section */}


### PR DESCRIPTION
## Summary
- remove the navigation button from each static neighborhood page
- drop the link on the React NeighborhoodPage

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm install` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6872eac506fc832296be3adacc9a757b