### PR TITLE
Update opening animation to local Lottie

### DIFF
--- a/frontend/src/pages/LocationPage.jsx
+++ b/frontend/src/pages/LocationPage.jsx
@@ -17,7 +17,7 @@ const PassportStampAnimation = ({ onDone }) => {
     }}>
       <lottie-player
         autoplay
-        src="https://embed.lottiefiles.com/animation/bdfd649b-cd1e-4ff8-8e8f-5c253b19401d"
+        src="/assets/images/visa_lottie"
         style={{ width: 300, height: 300 }}
       />
     </div>

--- a/frontend/src/pages/NeighborhoodPage.jsx
+++ b/frontend/src/pages/NeighborhoodPage.jsx
@@ -270,24 +270,11 @@ const PassportStampAnimation = ({ onDone }) => {
       background: 'rgba(255,255,255,0.95)', zIndex: 1000, display: 'flex',
       alignItems: 'center', justifyContent: 'center', transition: 'opacity 0.5s'
     }}>
-      <div style={{ textAlign: 'center' }}>
-        <svg width="160" height="160" viewBox="0 0 160 160">
-          <circle cx="80" cy="80" r="70" fill="#fff" stroke="#1c69d4" strokeWidth="8" />
-          <text x="50%" y="54%" textAnchor="middle" fill="#1c69d4"
-            fontSize="32" fontWeight="bold" fontFamily="Arial" dy=".3em">BMW</text>
-        </svg>
-        <div style={{ marginTop: 24, fontSize: 28, color: '#1c69d4',
-          fontWeight: 'bold', fontFamily: 'Arial' }}>
-          <span style={{ animation: 'stamp 0.7s cubic-bezier(.36,2,.6,1) forwards' }}>STAMPED!</span>
-        </div>
-        <style>{`
-          @keyframes stamp {
-            0% { opacity: 0; transform: scale(2) rotate(-10deg); }
-            60% { opacity: 1; transform: scale(1.1) rotate(2deg); }
-            100% { opacity: 1; transform: scale(1) rotate(0deg); }
-          }
-        `}</style>
-      </div>
+      <lottie-player
+        autoplay
+        src="/assets/images/visa_lottie"
+        style={{ width: 300, height: 300 }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show `visa_lottie` animation for the stamp animation on both the Location and Neighborhood pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873c3c6444483228643f70ce379d216