### PR TITLE
Add cookie consent banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A scalable, BMW-branded digital passport experience for customer engagement and 
 - "My Passport" page shows collected stamps and user info
 - Multi-store support for different BMW locations/events
 - BMW branding: logo, colors, fonts
+- Cookie consent banner with option to opt out
 
 ## Tech Stack
 - **Frontend:** React (Vite)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import NeighborhoodPage from './pages/NeighborhoodPage';
 import RegisterPage from './pages/RegisterPage';
 import MyPassportPage from './pages/MyPassportPage';
 import AdminPage from './pages/AdminPage';
+import CookieBanner from './components/CookieBanner';
 import './App.css';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
         <Route path="/admin" element={<AdminPage />} />
         <Route path="*" element={<Navigate to="/location/lawrenceville" replace />} />
       </Routes>
+      <CookieBanner />
     </Router>
   );
 }

--- a/frontend/src/components/CookieBanner.jsx
+++ b/frontend/src/components/CookieBanner.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import Cookies from 'js-cookie';
+
+const bannerStyle = {
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  width: '100%',
+  background: '#1c69d4',
+  color: '#fff',
+  padding: '12px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  zIndex: 1000,
+};
+
+const btnStyle = {
+  background: '#fff',
+  color: '#1c69d4',
+  border: 'none',
+  borderRadius: 4,
+  padding: '6px 12px',
+  marginLeft: 8,
+  fontWeight: 'bold',
+  cursor: 'pointer',
+};
+
+const CookieBanner = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = Cookies.get('cookie_consent');
+    if (consent === undefined) {
+      setVisible(true);
+    }
+  }, []);
+
+  const accept = () => {
+    Cookies.set('cookie_consent', 'true', { expires: 365 });
+    setVisible(false);
+  };
+
+  const decline = () => {
+    Cookies.set('cookie_consent', 'false', { expires: 365 });
+    // remove previously set cookies
+    Object.keys(Cookies.get())
+      .filter(name =>
+        ['first_name', 'email', 'user_id', 'store_id'].includes(name) ||
+        name.startsWith('stamp_location_')
+      )
+      .forEach(name => Cookies.remove(name));
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div style={bannerStyle}>
+      <span>
+        We use cookies to enhance your experience. You may opt out if you wish.
+      </span>
+      <div>
+        <button style={btnStyle} onClick={decline}>Opt Out</button>
+        <button style={btnStyle} onClick={accept}>Accept</button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/frontend/src/cookieUtils.js
+++ b/frontend/src/cookieUtils.js
@@ -1,0 +1,8 @@
+import Cookies from 'js-cookie';
+
+export const setCookieIfConsented = (name, value, options) => {
+  const consent = Cookies.get('cookie_consent');
+  if (consent !== 'false') {
+    Cookies.set(name, value, options);
+  }
+};

--- a/frontend/src/pages/LocationPage.jsx
+++ b/frontend/src/pages/LocationPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Cookies from 'js-cookie';
+import { setCookieIfConsented } from '../cookieUtils';
 import bmwLogo from '../assets/bmw-logo.svg';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
@@ -50,9 +51,9 @@ const LocationPage = () => {
             setError(data.error);
           } else {
             setLocation(data);
-            Cookies.set(`stamp_location_${id}`, 'true', { expires: 365 });
+            setCookieIfConsented(`stamp_location_${id}`, 'true', { expires: 365 });
             if (data.store_id) {
-              Cookies.set('store_id', data.store_id, { expires: 365 });
+              setCookieIfConsented('store_id', data.store_id, { expires: 365 });
             }
           }
         })
@@ -75,7 +76,7 @@ const LocationPage = () => {
   const handleFirstNameSubmit = (e) => {
     e.preventDefault();
     if (firstNameInput.trim()) {
-      Cookies.set('first_name', firstNameInput.trim(), { expires: 365 });
+      setCookieIfConsented('first_name', firstNameInput.trim(), { expires: 365 });
       setFirstName(firstNameInput.trim());
       setShowFirstNamePrompt(false);
     }
@@ -84,7 +85,7 @@ const LocationPage = () => {
   const handleEmailSubmit = async (e) => {
     e.preventDefault();
     if (emailInput.trim()) {
-      Cookies.set('email', emailInput.trim(), { expires: 365 });
+      setCookieIfConsented('email', emailInput.trim(), { expires: 365 });
       setEmail(emailInput.trim());
       setShowEmailPrompt(false);
       // Register user
@@ -99,7 +100,7 @@ const LocationPage = () => {
         });
         const data = await res.json();
         if (data.user_id) {
-          Cookies.set('user_id', data.user_id, { expires: 365 });
+          setCookieIfConsented('user_id', data.user_id, { expires: 365 });
         }
       } catch {}
     }

--- a/frontend/src/pages/MyPassportPage.jsx
+++ b/frontend/src/pages/MyPassportPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Cookies from 'js-cookie';
+import { setCookieIfConsented } from '../cookieUtils';
 import bmwLogo from '../assets/bmw-logo.svg';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
@@ -29,7 +30,7 @@ const MyPassportPage = () => {
           if (!firstName && data.user && data.user.name) {
             const fn = data.user.name.split(' ')[0];
             setFirstName(fn);
-            Cookies.set('first_name', fn, { expires: 365 });
+            setCookieIfConsented('first_name', fn, { expires: 365 });
           }
         }
         setLoading(false);

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Cookies from 'js-cookie';
+import { setCookieIfConsented } from '../cookieUtils';
 import bmwLogo from '../assets/bmw-logo.svg';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
@@ -32,7 +33,7 @@ const RegisterPage = () => {
       });
       const data = await res.json();
       if (res.ok) {
-        Cookies.set('user_id', data.user_id, { expires: 365 });
+        setCookieIfConsented('user_id', data.user_id, { expires: 365 });
         setSuccess(true);
       } else {
         setError(data.error || 'Registration failed');


### PR DESCRIPTION
## Summary
- add global CookieBanner component
- gate cookie writes with `setCookieIfConsented`
- expose cookie helper and use in pages
- document cookie banner feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68744d1946ac8322980a626ee52cedab