### PR TITLE
Add contest rules page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import NeighborhoodPage from './pages/NeighborhoodPage';
 import RegisterPage from './pages/RegisterPage';
 import MyPassportPage from './pages/MyPassportPage';
 import AdminPage from './pages/AdminPage';
+import OfficialRulesPage from './pages/OfficialRulesPage';
 import CookieBanner from './components/CookieBanner';
 import './App.css';
 
@@ -15,6 +16,7 @@ function App() {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/my-passport" element={<MyPassportPage />} />
         <Route path="/admin" element={<AdminPage />} />
+        <Route path="/official-rules" element={<OfficialRulesPage />} />
         <Route path="*" element={<Navigate to="/location/lawrenceville" replace />} />
       </Routes>
       <CookieBanner />

--- a/frontend/src/pages/NeighborhoodPage.jsx
+++ b/frontend/src/pages/NeighborhoodPage.jsx
@@ -498,6 +498,11 @@ const NeighborhoodPage = () => {
             Pittsburgh's most vibrant neighborhoods. Explore each stop, collect
             your stamps and enjoy the journey.
           </p>
+          <p style={{ marginTop: 16 }}>
+            <Link to="/official-rules" style={{ color: '#1c69d4' }}>
+              Official Rules
+            </Link>
+          </p>
         </section>
       </div>
 

--- a/frontend/src/pages/OfficialRulesPage.jsx
+++ b/frontend/src/pages/OfficialRulesPage.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const OfficialRulesPage = () => (
+  <section style={{ fontFamily: 'Arial, sans-serif', lineHeight: 1.6, maxWidth: 800, margin: 'auto', padding: 20 }}>
+    <h1 style={{ color: '#003A70' }}>BMW of Pittsburgh “How to Pittsburgh” Getaway</h1>
+    <h2 style={{ color: '#666' }}>Official Rules</h2>
+    <p><strong>No purchase necessary to enter or win.</strong></p>
+    <h3>1. Eligibility</h3>
+    <p>Open to U.S. residents 21 years of age or older as of July 23, 2025. Employees of BMW of Pittsburgh, MINI of Pittsburgh, Table Magazine, and their immediate families are not eligible.</p>
+    <p><strong>Note:</strong> To claim the BMW weekend experience, the winner must be 25+ with a valid driver’s license and insurance. Winners under 25 will receive the dining prize only.</p>
+    <h3>2. How to Enter</h3>
+    <p>Attend the Table Magazine “How to Pittsburgh” event on <strong>July 23, 2025</strong>. Use the Passport app to scan QR codes at participating locations. Each scan earns a digital stamp. Completing the Passport (all required scans) automatically enters you to win.</p>
+    <h3>3. Contest Period</h3>
+    <p>Valid only on July 23, 2025. All entries must be completed before the end of the event.</p>
+    <h3>4. Prize</h3>
+    <ul>
+      <li>A weekend loan (Friday–Monday) of a BMW vehicle from BMW of Pittsburgh — <em>available only to winners 25+ with valid license and insurance</em>.</li>
+      <li>Two (2) $200 gift certificates to featured restaurants from the event (selected by BMW of Pittsburgh).</li>
+    </ul>
+    <p>Total prize value: Approx. $1,000. BMW model subject to availability and terms of the loaner agreement.</p>
+    <h3>5. Winner Selection</h3>
+    <p>One winner will be selected at random from all eligible completed entries. Winner will be notified by July 26, 2025 via email or phone. If unresponsive within 72 hours, an alternate may be chosen.</p>
+    <h3>6. General Conditions</h3>
+    <p>By entering, participants agree to these rules and the sponsor’s decisions. BMW of Pittsburgh may modify or cancel the contest at any time. Acceptance of the prize grants permission to use the winner’s name and likeness in promotional materials unless prohibited by law.</p>
+    <h3>7. Sponsor</h3>
+    <p>BMW of Pittsburgh<br />
+    4801 Baum Blvd, Pittsburgh, PA 15213<br />
+    412-682-0788</p>
+  </section>
+);
+
+export default OfficialRulesPage;


### PR DESCRIPTION
## Summary
- create OfficialRulesPage with full text
- link to page from NeighborhoodPage
- add route for new page in App router

## Testing
- `npm run lint` *(fails: Cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68745da507488322b15fdec7124a746a