### PR TITLE
Update pages to use new assets

### DIFF
--- a/frontend/src/pages/LocationPage.jsx
+++ b/frontend/src/pages/LocationPage.jsx
@@ -4,9 +4,17 @@ import Cookies from 'js-cookie';
 import { setCookieIfConsented } from '../cookieUtils';
 import bmwLogo from '../assets/bmw-logo.svg';
 
+const LOTTIE_MAP = {
+  Lawrenceville: '/assets/lotties/Lawrenceville Stamp.json',
+  'Strip District': '/assets/lotties/Strip District Stamp.json',
+  Downtown: '/assets/lotties/Downtown Stamp.json',
+  Bloomfield: '/assets/lotties/Bloomfield Stamp.json',
+  Shadyside: '/assets/lotties/Shadyside Stamp.json',
+};
+
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
 
-const PassportStampAnimation = ({ onDone }) => {
+const PassportStampAnimation = ({ onDone, src }) => {
   useEffect(() => {
     const timer = setTimeout(onDone, 3000);
     return () => clearTimeout(timer);
@@ -18,7 +26,7 @@ const PassportStampAnimation = ({ onDone }) => {
     }}>
       <lottie-player
         autoplay
-        src="/assets/images/visa_lottie"
+        src={src || '/assets/images/visa_lottie'}
         style={{ width: 300, height: 300 }}
       />
     </div>
@@ -112,7 +120,12 @@ const LocationPage = () => {
 
   return (
     <div style={{ textAlign: 'center', padding: '2rem', background: '#fff', minHeight: '100vh' }}>
-      {showAnimation && <PassportStampAnimation onDone={() => setShowAnimation(false)} />}
+      {showAnimation && (
+        <PassportStampAnimation
+          onDone={() => setShowAnimation(false)}
+          src={location ? LOTTIE_MAP[location.name] : undefined}
+        />
+      )}
       {!showAnimation && (
         <>
           <img src={bmwLogo} alt="BMW Logo" style={{ width: 100, marginBottom: 24 }} />

--- a/frontend/src/pages/MyPassportPage.jsx
+++ b/frontend/src/pages/MyPassportPage.jsx
@@ -3,6 +3,14 @@ import Cookies from 'js-cookie';
 import { setCookieIfConsented } from '../cookieUtils';
 import bmwLogo from '../assets/bmw-logo.svg';
 
+const STAMP_IMAGES = {
+  Lawrenceville: '/assets/stamps/lawrenceville.svg',
+  'Strip District': '/assets/stamps/strip_district.svg',
+  Downtown: '/assets/stamps/downtown.svg',
+  Bloomfield: '/assets/stamps/bloomfield.svg',
+  Shadyside: '/assets/stamps/shadyside.svg',
+};
+
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
 
 const MyPassportPage = () => {
@@ -82,15 +90,35 @@ const MyPassportPage = () => {
             {collectedStamps.length === 0 && <li>No stamps collected yet.</li>}
             {collectedStamps.map(id => {
               const dbStamp = stamps.find(s => String(s.location_id) === id);
+              const imgSrc = dbStamp ? STAMP_IMAGES[dbStamp.location_name] : null;
               return (
-                <li key={id} style={{ marginBottom: 12, padding: 8, background: '#f4f8fb', borderRadius: 6 }}>
-                  <span role="img" aria-label="stamp">📍</span> Location {id}
-                  {dbStamp && dbStamp.location_name && (
-                    <> - <strong>{dbStamp.location_name}</strong></>
+                <li
+                  key={id}
+                  style={{
+                    marginBottom: 12,
+                    padding: 8,
+                    background: '#f4f8fb',
+                    borderRadius: 6,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                  }}
+                >
+                  {imgSrc && (
+                    <img
+                      src={imgSrc}
+                      alt={dbStamp.location_name}
+                      style={{ width: 80 }}
+                    />
                   )}
-                  {dbStamp && dbStamp.timestamp && (
-                    <div style={{ fontSize: 12, color: '#888' }}>Visited: {new Date(dbStamp.timestamp).toLocaleString()}</div>
-                  )}
+                  <div>
+                    <strong>{dbStamp ? dbStamp.location_name : `Location ${id}`}</strong>
+                    {dbStamp && dbStamp.timestamp && (
+                      <div style={{ fontSize: 12, color: '#888' }}>
+                        Visited: {new Date(dbStamp.timestamp).toLocaleString()}
+                      </div>
+                    )}
+                  </div>
                 </li>
               );
             })}

--- a/frontend/src/pages/NeighborhoodPage.jsx
+++ b/frontend/src/pages/NeighborhoodPage.jsx
@@ -11,6 +11,8 @@ const NEIGHBORHOODS = {
   lawrenceville: {
     title: 'Lawrenceville',
     hero: '/assets/images/neighborhoods/lawrenceville_hero.jpg',
+    logo: '/assets/images/location_logos/lawrenceville_icon.jpg',
+    lottie: '/assets/lotties/Lawrenceville Stamp.json',
     tagline: 'Where History Meets Innovation',
     welcome: 'Welcome to Lawrenceville',
     intro: `Discover one of Pittsburgh's oldest and most vibrant neighborhoods, where historic charm meets contemporary creativity. Located less than three miles from Downtown Pittsburgh, Lawrenceville has transformed from its industrial roots into a thriving cultural hub.`,
@@ -48,7 +50,7 @@ const NEIGHBORHOODS = {
       },
       {
         name: 'Parlor Dim Sum',
-        image: '/assets/images/restaurants/parlor_dim_sum.jpg',
+        image: '/assets/images/restaurants/parlor_dimsum.jpg',
         description:
           'Chef Roger Li’s modern Cantonese spot for late-night dim sum, cocktails and Cantonese BBQ – think “little Hong Kong” on Butler St.',
         website: 'https://theparlordimsum.com',
@@ -57,7 +59,7 @@ const NEIGHBORHOODS = {
       },
       {
         name: "Burgh'ers Brewing",
-        image: '/assets/images/restaurants/burghers_brewing.jpg',
+        image: '/assets/images/restaurants/burghers.jpg',
         description:
           'Chef-driven smash-burger joint & craft brewery focused on local, ethical and sustainable beef & beer.',
         website: 'https://burgherspgh.com/lawrenceville',
@@ -75,6 +77,8 @@ const NEIGHBORHOODS = {
   strip_district: {
     title: 'Strip District',
     hero: '/assets/images/neighborhoods/strip_district_hero.jpg',
+    logo: '/assets/images/location_logos/stripdistrict_icon.jpg',
+    lottie: '/assets/lotties/Strip District Stamp.json',
     tagline: 'Where Industry Meets Culinary Excellence',
     welcome: 'Welcome to the Strip District',
     intro: `Nestled along the Allegheny River, the Strip District blends Pittsburgh’s past with its foodie present. Warehouses now house bustling markets, tech offices, cafés and destination restaurants.`,
@@ -98,7 +102,7 @@ const NEIGHBORHOODS = {
       },
       {
         name: 'De Fer Coffee & Tea',
-        image: '/assets/images/restaurants/de_fer.jpg',
+        image: '/assets/images/restaurants/defer_coffee.jpg',
         description:
           'Flagship roastery-café pouring single-origin coffee, tea, natural wine and craft cocktails – plus weekend live music – inside a lofty Smallman St. space.',
         website: 'https://www.defer.coffee/strip-district',
@@ -116,6 +120,8 @@ const NEIGHBORHOODS = {
   downtown: {
     title: 'Downtown',
     hero: '/assets/images/neighborhoods/downtown_hero.jpg',
+    logo: '/assets/images/location_logos/downtown_icon.jpg',
+    lottie: '/assets/lotties/Downtown Stamp.json',
     tagline: 'The Heart of Pittsburgh',
     welcome: 'Welcome to Downtown',
     intro: `Explore the Golden Triangle where skyscrapers meet three rivers, theater marquis glow and new restaurants pop up next to century-old landmarks.`,
@@ -166,6 +172,8 @@ const NEIGHBORHOODS = {
   bloomfield: {
     title: 'Bloomfield',
     hero: '/assets/images/neighborhoods/bloomfield_hero.jpg',
+    logo: '/assets/images/location_logos/bloomfield_icon.jpg',
+    lottie: '/assets/lotties/Bloomfield Stamp.json',
     tagline: `Pittsburgh's Little Italy`,
     welcome: 'Welcome to Bloomfield',
     intro: `Discover Bloomfield, a neighborhood where old-school Italian red-sauce joints share the block with buzzy new cocktail bars and international kitchens.`,
@@ -180,7 +188,7 @@ const NEIGHBORHOODS = {
     restaurants: [
       {
         name: "Khalil's",
-        image: '/assets/images/restaurants/khalils.jpg',
+        image: '/assets/images/restaurants/khalils.avif',
         description:
           'Family-run Syrian restaurant (since 1972) serving mezze platters, kebabs and legendary house-baked pita in an ornately tiled dining room.',
         website: 'https://khalilsrestaurant.com',
@@ -207,6 +215,8 @@ const NEIGHBORHOODS = {
   shadyside: {
     title: 'Shadyside',
     hero: '/assets/images/neighborhoods/shadyside_hero.jpg',
+    logo: '/assets/images/location_logos/shadyside_icon.jpg',
+    lottie: '/assets/lotties/Shadyside Stamp.json',
     tagline: 'Historic Elegance Meets Modern Luxury',
     welcome: 'Welcome to Shadyside',
     intro: `Tree-lined streets, Victorian mansions and three boutique shopping districts make Shadyside an East-End favorite.`,
@@ -259,7 +269,7 @@ const NEIGHBORHOODS = {
   },
 
 };
-const PassportStampAnimation = ({ onDone }) => {
+const PassportStampAnimation = ({ onDone, src }) => {
   useEffect(() => {
     const timer = setTimeout(onDone, 2000);
     return () => clearTimeout(timer);
@@ -272,7 +282,7 @@ const PassportStampAnimation = ({ onDone }) => {
     }}>
       <lottie-player
         autoplay
-        src="/assets/images/visa_lottie"
+        src={src || '/assets/images/visa_lottie'}
         style={{ width: 300, height: 300 }}
       />
     </div>
@@ -311,7 +321,12 @@ const NeighborhoodPage = () => {
         textDecoration: 'none', boxShadow: '0 2px 8px #eee'
       }}>My Passport</Link>
 
-      {showAnimation && <PassportStampAnimation onDone={() => setShowAnimation(false)} />}
+      {showAnimation && (
+        <PassportStampAnimation
+          onDone={() => setShowAnimation(false)}
+          src={n.lottie}
+        />
+      )}
 
       {/* hide content behind animation */}
       <div style={{ display: showAnimation ? 'none' : 'block' }}>
@@ -327,21 +342,20 @@ const NeighborhoodPage = () => {
           }}
         >
           {/* Placeholder for a location-specific logo */}
-          <div
-            style={{
-              width: 120,
-              height: 120,
-              margin: '0 auto 16px',
-              background: 'rgba(255,255,255,0.7)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: '#1c69d4',
-              borderRadius: '50%',
-            }}
-          >
-            [Location Logo]
-          </div>
+          {n.logo && (
+            <img
+              src={n.logo}
+              alt={`${n.title} logo`}
+              style={{
+                width: 120,
+                height: 120,
+                margin: '0 auto 16px',
+                borderRadius: '50%',
+                objectFit: 'cover',
+                background: '#fff',
+              }}
+            />
+          )}
           <h1 style={{ margin: 0 }}>{n.title}</h1>
           <p style={{ fontSize: 20 }}>{n.tagline}</p>
         </section>


### PR DESCRIPTION
## Summary
- add location logos and lottie paths to neighborhood data
- show location logo in NeighborhoodPage hero
- use location-specific lotties in NeighborhoodPage and LocationPage
- display stamp images on MyPassportPage
- update restaurant image paths

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run lint` *(fails: cannot find module due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6875956ad1a48322b70a0ac9cd275e50