### PR TITLE
Remove next buttons and add contest note

### DIFF
--- a/PAGES/bloomfield.html
+++ b/PAGES/bloomfield.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Shadyside, where historic elegance meets modern luxury.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/bloomfield_fixed.html
+++ b/PAGES/bloomfield_fixed.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Shadyside, where historic elegance meets modern luxury.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/downtown.html
+++ b/PAGES/downtown.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Bloomfield, Pittsburgh's "Little Italy," where European heritage and culinary traditions await.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/lawrenceville.html
+++ b/PAGES/lawrenceville.html
@@ -93,12 +93,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to the Strip District, where the city's industrial past meets its culinary present.</p>
-                    <li><a href="downtown.html">Downtown</a></li>
-            </div>
         </div>
     </section>
 

--- a/PAGES/lawrenceville_fixed.html
+++ b/PAGES/lawrenceville_fixed.html
@@ -93,12 +93,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to the Strip District, where the city's industrial past meets its culinary present.</p>
-                    <li><a href="downtown.html">Downtown</a></li>
-            </div>
         </div>
     </section>
 

--- a/PAGES/shadyside.html
+++ b/PAGES/shadyside.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Congratulations!</h3>
-                <p>You've completed the BMW Charity Scavenger Hunt across Pittsburgh's vibrant neighborhoods. Return to any location to see your progress or start again from the beginning.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/shadyside_fixed.html
+++ b/PAGES/shadyside_fixed.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Congratulations!</h3>
-                <p>You've completed the BMW Charity Scavenger Hunt across Pittsburgh's vibrant neighborhoods. Return to any location to see your progress or start again from the beginning.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/strip_district.html
+++ b/PAGES/strip_district.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Downtown Pittsburgh, the city's central district brimming with cultural landmarks.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/PAGES/strip_district_fixed.html
+++ b/PAGES/strip_district_fixed.html
@@ -88,12 +88,6 @@
                 <!-- Progress will be displayed here by JavaScript -->
             </div>
             
-            <!-- Next Location Hint -->
-            <div class="next-location-hint text-center mt-4 mb-5">
-                <h3>Your Next Destination</h3>
-                <p>Continue your journey through Pittsburgh's vibrant neighborhoods by heading to Downtown Pittsburgh, the city's central district brimming with cultural landmarks.</p>
-            </div>
-        </div>
     </section>
 
     <!-- BMW Branding Section -->

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #000;
+  background-color: #fff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -56,7 +55,7 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
+    color: #000;
     background-color: #ffffff;
   }
   a:hover {

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -32,6 +32,9 @@ const AdminPage = () => {
   return (
     <div style={{ maxWidth: 900, margin: '2rem auto', background: '#fff', padding: 32, borderRadius: 12, boxShadow: '0 2px 8px #eee', color: '#000' }}>
       <h1 style={{ color: '#1c69d4', marginBottom: 24 }}>Admin Dashboard</h1>
+      <p style={{ fontSize: 14, color: '#1c69d4', fontWeight: 'bold', marginBottom: 24 }}>
+        Contest progress overview
+      </p>
       <h2 style={{ color: '#222', fontSize: 22, marginBottom: 16 }}>Stats</h2>
       <ul style={{ fontSize: 18, marginBottom: 24, color: '#000' }}>
         <li><strong>Total Users:</strong> {stats.user_count}</li>

--- a/frontend/src/pages/LocationPage.jsx
+++ b/frontend/src/pages/LocationPage.jsx
@@ -135,6 +135,9 @@ const LocationPage = () => {
           {firstName && <div style={{ fontSize: 22, color: '#1c69d4', marginBottom: 12 }}>Welcome back, {firstName}!</div>}
           <p style={{ fontSize: 18 }}>You just collected a digital stamp for your passport.</p>
           <p style={{ color: '#888' }}>Scan more QR codes at other locations to collect more stamps.</p>
+          <p style={{ color: '#1c69d4', fontWeight: 'bold' }}>
+            Complete your passport for a chance to win our BMW contest!
+          </p>
         </>
       )}
       {/* First Name Prompt */}

--- a/frontend/src/pages/MyPassportPage.jsx
+++ b/frontend/src/pages/MyPassportPage.jsx
@@ -58,6 +58,9 @@ const MyPassportPage = () => {
     <div style={{ maxWidth: 500, margin: '2rem auto', background: '#fff', padding: 32, borderRadius: 12, boxShadow: '0 2px 8px #eee' }}>
       <img src={bmwLogo} alt="BMW Logo" style={{ width: 80, display: 'block', margin: '0 auto 24px' }} />
       <h2 style={{ color: '#1c69d4', textAlign: 'center' }}>My BMW Digital Passport</h2>
+      <p style={{ fontSize: 16, color: '#1c69d4', fontWeight: 'bold', marginBottom: 16, textAlign: 'center' }}>
+        Collect all five stamps to be entered in the BMW contest!
+      </p>
       {loading ? (
         <p>Loading...</p>
       ) : error ? (

--- a/frontend/src/pages/NeighborhoodPage.jsx
+++ b/frontend/src/pages/NeighborhoodPage.jsx
@@ -364,6 +364,9 @@ const NeighborhoodPage = () => {
         <section style={{ maxWidth: 800, margin: '0 auto', padding: 32 }}>
           <h2 style={{ color: '#1c69d4' }}>{n.welcome}</h2>
           <p style={{ fontSize: 18, marginBottom: 24 }}>{n.intro}</p>
+          <p style={{ fontSize: 16, color: '#1c69d4', fontWeight: 'bold', marginBottom: 24 }}>
+            Collect all stamps to enter our BMW "How to Pittsburgh" contest!
+          </p>
           {n.featureImg && (
             <img
               src={n.featureImg}
@@ -445,35 +448,6 @@ const NeighborhoodPage = () => {
             </section>
           )}
 
-          {n.next && (
-            <section
-              style={{
-                margin: '48px 0',
-                background: '#f4f8fb',
-                padding: 24,
-                borderRadius: 8,
-                textAlign: 'center',
-              }}
-            >
-              <h3 style={{ color: '#1c69d4', marginBottom: 12 }}>
-                Your Next Destination
-              </h3>
-              <p style={{ marginBottom: 16 }}>{n.next.text}</p>
-              <Link
-                to={`/location/${n.next.slug}`}
-                style={{
-                  background: '#1c69d4',
-                  color: '#fff',
-                  padding: '10px 24px',
-                  borderRadius: 6,
-                  textDecoration: 'none',
-                  fontWeight: 'bold',
-                }}
-              >
-                {n.next.label}
-              </Link>
-            </section>
-          )}
         </section>
         {/* BMW Branding */}
         <section

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -68,6 +68,9 @@ const RegisterPage = () => {
     <div style={{ maxWidth: 400, margin: '2rem auto', background: '#fff', padding: 32, borderRadius: 12, boxShadow: '0 2px 8px #eee' }}>
       <img src={bmwLogo} alt="BMW Logo" style={{ width: 80, display: 'block', margin: '0 auto 24px' }} />
       <h2 style={{ color: '#1c69d4', textAlign: 'center' }}>Register Your Passport</h2>
+      <p style={{ fontSize: 16, color: '#1c69d4', fontWeight: 'bold', textAlign: 'center', marginBottom: 16 }}>
+        Finish your passport to enter the BMW "How to Pittsburgh" contest!
+      </p>
       <form onSubmit={handleSubmit}>
         {!form.name && (
           <>


### PR DESCRIPTION
## Summary
- clean up location pages by removing "Next Destination" hints
- add contest callouts across React pages
- update default text color to black

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6875a5ad048c8322b21a196155b13009