### PR TITLE
Add links to banner images

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,13 @@
     <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
   </head>
   <body>
-    <img class="banner-ad" src="/assets/images/BMW-MINI-Chris-Page-Header-Basic-Updated.png" alt="Top Banner" />
+    <a href="https://www.bmwofpittsburgh.com/thank-you-for-participating.htm" target="_blank" rel="noopener noreferrer">
+      <img class="banner-ad" src="/assets/images/BMW-MINI-Chris-Page-Header-Basic-Updated.png" alt="Top Banner" />
+    </a>
     <div id="root"></div>
-    <img class="banner-ad" src="/assets/images/BMW-MINI-Chris-Page-Header-Offer-Updated-2.png" alt="Bottom Banner" />
+    <a href="https://www.bmwofpittsburgh.com/thank-you-for-participating.htm" target="_blank" rel="noopener noreferrer">
+      <img class="banner-ad" src="/assets/images/BMW-MINI-Chris-Page-Header-Offer-Updated-2.png" alt="Bottom Banner" />
+    </a>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- make both banner images on the landing page open the BMW Pittsburgh "thank you" page when clicked

## Testing
- `npm --prefix frontend run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6886958676908322902c4611dc9b11ba